### PR TITLE
Improves writing of FEDEFL flows and other minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ A Python virtual environment (v 3.11 or higher) is required with the following p
         + certifi-2024.2.2
         + charset-normalizer-3.3.2
         + esupy-0.3.2
-        + fedelemflowlist-1.2.2
+        + fedelemflowlist-1.2.3
         + idna-3.6
         + jmespath-1.0.1
         + numpy-1.26.4

--- a/electricitylci/generation.py
+++ b/electricitylci/generation.py
@@ -799,7 +799,11 @@ def create_generation_process_df():
                 'PGM_SYS_ACRNM': "str",
                 'PGM_SYS_ID': "str"
             }
+            if not (fmglob.FRSpath / file_).exists():
+                fmglob.download_extract_FRS_combined_national(file_)
             FRS_bridge = fmglob.read_FRS_file(file_, col_dict)
+            # ^^ these lines could be replaced by a future improved fxn 
+            # in FacilityMatcher
             eia860_FRS = fmglob.filter_by_program_list(
                 df=FRS_bridge, program_list=["EIA-860"]
             )

--- a/electricitylci/olca_jsonld_writer.py
+++ b/electricitylci/olca_jsonld_writer.py
@@ -1874,10 +1874,10 @@ def _save_to_json(json_file, e_dict):
                     k_dict = k_obj.to_dict()
                     k_obj = e_dict[k_type]['class'].from_dict(k_dict)
 
-                logging.debug("Writing %s entity (%s)" % (k, k_obj.id))
                 if k == "Flow" and k_obj.id in flows['Flow UUID'].values:
                     # all FEDEFL flows written above
                     continue
+                logging.debug("Writing %s entity (%s)" % (k, k_obj.id))
                 writer.write(k_obj)
 
 

--- a/electricitylci/olca_jsonld_writer.py
+++ b/electricitylci/olca_jsonld_writer.py
@@ -208,10 +208,10 @@ def clean_json(file_path):
             for e in p.exchanges:
                 # Get the flow type
                 fid = data["Flow"]['ids'].index(e.flow.id)
-                f_type = data["Flow"]['objs'][fid]
+                f_obj = data["Flow"]['objs'][fid]
                 # Remove if flow is a product flow with zero exchange value
                 # NOTE: don't add as an exchange flow!
-                if e.amount == 0 and f_type != o.FlowType.ELEMENTARY_FLOW:
+                if e.amount == 0 and f_obj.flow_type != o.FlowType.ELEMENTARY_FLOW:
                     logging.debug(
                         "Removing zero product flow, %s, from %s" % (
                             e.flow.name, p.name))
@@ -222,10 +222,10 @@ def clean_json(file_path):
                 # Check to see if output exchange is labeled as a
                 # resource flow
                 # https://github.com/USEPA/ElectricityLCI/issues/233
-                if not e.is_input and 'resource' in f_type.category.lower():
+                if not e.is_input and 'resource' in f_obj.category.lower():
                     logging.warning(
                         "Fixing resource flow in output exchange! "
-                        "'%s' in %s (%s)" % (f_type.name, p.name, p.id))
+                        "'%s' in %s (%s)" % (f_obj.name, p.name, p.id))
                     # HOTFIX: remove troublesome exchange, fix meta & re-add:
                     p.exchanges.remove(e)
                     e.is_input = True


### PR DESCRIPTION
3 commits each described separately:

1. By writing flows with fedelemflowlist, this ensures the metadata is accurate and consistent, and avoids the need to update the metadata in post processing (I did not remove those functions which are now extraneous).
2. Minor fix to clean_json where 0 values for elementary flows were getting dropped
3. A likely edge case with FacilityMatcher, where I had processed FRS files but not the original FRS files so the FRS Bridge was not found, causing an error. This commit checks for the file before loading, and will download if not present.