### PR TITLE
enable US generation profiles using `regional_aggregation: "US"`

### DIFF
--- a/electricitylci/__init__.py
+++ b/electricitylci/__init__.py
@@ -167,11 +167,17 @@ def get_consumption_mix_df(subregion=None, regions_to_keep=None):
     if subregion is None:
         subregion = config.model_specs.regional_aggregation
 
-    io_trade_df = trade.ba_io_trading_model(
-        year=config.model_specs.NETL_IO_trading_year,
-        subregion=subregion,
-        regions_to_keep=regions_to_keep
-    )
+    if subregion == 'US':
+        # set consumption mix equal to generation mix
+        df = pd.DataFrame({'fraction': [1.0],
+                           'export_name': ['US']})
+        io_trade_df = {"US": df}
+    else:
+        io_trade_df = trade.ba_io_trading_model(
+            year=config.model_specs.NETL_IO_trading_year,
+            subregion=subregion,
+            regions_to_keep=regions_to_keep
+        )
     return io_trade_df
 
 
@@ -312,8 +318,8 @@ def get_generation_mix_process_df(regions=None):
     if regions is None:
         regions = config.model_specs.regional_aggregation
 
-    if config.model_specs.replace_egrid or regions in ["BA", "FERC", "US"]:
-        if regions in ["BA","FERC","US"] and not (
+    if config.model_specs.replace_egrid or regions in ["BA", "FERC"]:
+        if regions in ["BA","FERC"] and not (
                 config.model_specs.replace_egrid):
             logging.info(
                 "EIA923 generation data are being used for the generation mix "
@@ -465,7 +471,7 @@ def get_generation_process_df(regions=None, **kwargs):
         if regions is None:
             regions = config.model_specs.regional_aggregation
 
-        if regions in ["BA", "FERC", "US"]:
+        if regions in ["BA", "FERC"]:
             generation_process_df = aggregate_gen(gen_plus_fuels, "BA")
         else:
             generation_process_df = aggregate_gen(gen_plus_fuels, regions)
@@ -918,7 +924,7 @@ def write_generation_mix_database_to_dict(genmix_db, gen_dict, regions=None):
 
     if regions is None:
         regions = config.model_specs.regional_aggregation
-    if regions in ["FERC","US","BA"]:
+    if regions in ["BA","FERC"]:
         regions = "BA"
     genmix_dict = olcaschema_genmix(genmix_db, gen_dict, regions)
 

--- a/electricitylci/generation_mix.py
+++ b/electricitylci/generation_mix.py
@@ -191,23 +191,24 @@ def create_generation_mix_process_df_from_model_generation_data(
             :
         ]
 
-    canada_list=[]
-    canada_subregions = [
-        "B.C. Hydro & Power Authority",
-        "Hydro-Quebec TransEnergie",
-        "Manitoba Hydro",
-        "New Brunswick System Operator",
-        "Ontario IESO"
-    ]
-    for reg in canada_subregions:
-        canada_list.append((reg,"ALL",1.0,1.0))
-    canada_df = pd.DataFrame(
-        canada_list,
-        columns=["Subregion","FuelCategory","Electricity","Generation_Ratio"]
-    )
-    subregion_fuel_gen = pd.concat(
-        [subregion_fuel_gen,canada_df],
-        ignore_index=True)
+    if subregion != "US":
+        canada_list=[]
+        canada_subregions = [
+            "B.C. Hydro & Power Authority",
+            "Hydro-Quebec TransEnergie",
+            "Manitoba Hydro",
+            "New Brunswick System Operator",
+            "Ontario IESO"
+        ]
+        for reg in canada_subregions:
+            canada_list.append((reg,"ALL",1.0,1.0))
+        canada_df = pd.DataFrame(
+            canada_list,
+            columns=["Subregion","FuelCategory","Electricity","Generation_Ratio"]
+        )
+        subregion_fuel_gen = pd.concat(
+            [subregion_fuel_gen,canada_df],
+            ignore_index=True)
     return subregion_fuel_gen
 
 

--- a/electricitylci/main.py
+++ b/electricitylci/main.py
@@ -124,11 +124,11 @@ def run_distribution(generation_process_dict):
     dict
         The regionalized distribution mix processes in openLCA schema format.
     """
-    # Force the generation of BA aggregation if doing FERC, US, or BA regions.
+    # Force the generation of BA aggregation if doing FERC or BA regions.
     # This is because the consumption mixes are based on imports from
     # balancing authority areas.
     logging.info("get gen mix process")
-    if config.model_specs.regional_aggregation in ["FERC", "US"]:
+    if config.model_specs.regional_aggregation in ["FERC"]:
         generation_mix_df = get_generation_mix_process_df("BA")
     else:
         generation_mix_df = get_generation_mix_process_df()
@@ -203,7 +203,7 @@ def run_generation():
     )
 
     logging.info("write generation process to dict")
-    if config.model_specs.regional_aggregation in ["FERC", "US"]:
+    if config.model_specs.regional_aggregation in ["FERC"]:
         generation_process_dict = write_gen_fuel_database_to_dict(
             generation_process_df, upstream_dict, subregion="BA"
         )


### PR DESCRIPTION
This was tested with `ELCI_2021` with using `regional_aggregation: "US"`

See the screenshot in https://github.com/USEPA/ElectricityLCI/issues/256#issuecomment-2345219658