### PR TITLE
Avoid dropping already mapped flows

### DIFF
--- a/electricitylci/combinator.py
+++ b/electricitylci/combinator.py
@@ -314,11 +314,11 @@ def concat_map_upstream_databases(eia_gen_year, *arg, **kwargs):
     upstream_df["FlowAmount"] = upstream_df["FlowAmount"].astype(float)
     if "Electricity" in upstream_df.columns:
         upstream_df_grp = upstream_df.groupby(
-            groupby_cols, as_index=False
+            groupby_cols, as_index=False, dropna=False
         ).agg({"FlowAmount": "sum", "quantity": "mean", "Electricity": "mean"})
     else:
         upstream_df_grp = upstream_df.groupby(
-            groupby_cols, as_index=False
+            groupby_cols, as_index=False, dropna=False
         ).agg({"FlowAmount": "sum", "quantity": "mean"})
 
     logging.info("Merging upstream database and flow mapping")


### PR DESCRIPTION
Resolves #274

This pulls in the full flowlist and appends to the mapping file in order to "map" already mapped flows.

This is a bit of a patchwork solution and I'd recommend the flow mapping be re-assessed for individual data sources down the line.