### PR TITLE
Updates for ELCI2023 + other minor bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ electricitylci/output/*
 
 # Whitelist everything except this!
 electricitylci/data/EFs/.DS_Store
+
+Notes.txt

--- a/electricitylci/egrid_facilities.py
+++ b/electricitylci/egrid_facilities.py
@@ -156,6 +156,7 @@ egrid_facilities = stewi.getInventoryFacilities(
 # Rename columns. NOTE: missing names resolved
 # (https://github.com/USEPA/standardizedinventories/issues/153)
 egrid_facilities.rename(columns={
+    'Plant primary fuel category': 'FuelCategory', # added for 2023 STEWI data
     'Plant primary coal/oil/gas/ other fossil fuel category': 'FuelCategory',
     'Plant primary fuel': 'PrimaryFuel',
     'eGRID subregion acronym': 'Subregion',

--- a/electricitylci/eia_trans_dist_grid_loss.py
+++ b/electricitylci/eia_trans_dist_grid_loss.py
@@ -99,7 +99,7 @@ def eia_trans_dist_download_extract(year):
             # HOTFIX: URLs for two-word states have space omitted.
             url_a = (
                 "https://www.eia.gov/electricity/state/archive/"
-                + year
+                + f"{year}"
                 + "/"
                 + key.replace(" ", "")
                 + "/xls/"
@@ -111,22 +111,39 @@ def eia_trans_dist_download_extract(year):
                 + "/xls/"
                 + filename
             )
+            # bugfix: url for year 2023 [FH]
+            # this has to be updated later when 2023 data gets archived 
+            # and links should be rechecked for compatibility with 2024 data (when released)
+            url_c = (
+                "https://www.eia.gov/electricity/state/"
+                + key.replace(" ", "")
+                + "/xls/"
+                + "SEP Tables for "
+                + STATE_ABBREV[key].upper()
+                + ".xlsx"
+            )           
             # HOTFIX: https://github.com/USEPA/ElectricityLCI/issues/235
             #adding 20s timeout to avoid long delays due to server issues.
-            r = requests.get(url_a, timeout=20)
-            r_head = r.headers.get("Content-Type", "")
-            if not r.ok or r_head.startswith("text"):
-                logging.info(f"Trying alternative site {STATE_ABBREV[key]}")
-                #adding 20s timeout to avoid long delays due to server issues.
-                r = requests.get(url_b, timeout=20)
-                r_head = r.headers.get("Content-Type", "")
-
-            if r.ok and not r_head.startswith("text"):
-                with open(filename, 'wb') as f:
+            # bugfix: added condition to account for the 2023 data link format [FH]
+            if year == "2023":
+                r = requests.get(url_c, timeout=20)
+                with open (filename, "wb") as f:
                     f.write(r.content)
             else:
-                logging.error(
-                    f"No TD loss data for {STATE_ABBREV[key]} {year}")
+                r = requests.get(url_a, timeout=20)
+                r_head = r.headers.get("Content-Type", "")
+                if not r.ok or r_head.startswith("text"):
+                    logging.info(f"Trying alternative site {STATE_ABBREV[key]}")
+                    #adding 20s timeout to avoid long delays due to server issues.
+                    r = requests.get(url_b, timeout=20)
+                    r_head = r.headers.get("Content-Type", "")
+
+                if r.ok and not r_head.startswith("text"):
+                    with open(filename, 'wb') as f:
+                        f.write(r.content)
+                else:
+                    logging.error(
+                        f"No TD loss data for {STATE_ABBREV[key]} {year}")
 
         try:
             df = pd.read_excel(
@@ -155,7 +172,8 @@ def eia_trans_dist_download_extract(year):
 
     eia_trans_dist_loss.columns = eia_trans_dist_loss.columns.str.upper()
     eia_trans_dist_loss = eia_trans_dist_loss.transpose()
-    eia_trans_dist_loss = eia_trans_dist_loss[[year]]
+    eia_trans_dist_loss = eia_trans_dist_loss[f"{year}"]
+    eia_trans_dist_loss = eia_trans_dist_loss.to_frame()
     eia_trans_dist_loss.columns = ["t_d_losses"]
     os.chdir(old_path)
 

--- a/electricitylci/eia_trans_dist_grid_loss.py
+++ b/electricitylci/eia_trans_dist_grid_loss.py
@@ -74,13 +74,16 @@ def eia_trans_dist_download_extract(year):
 
     Parameters
     ----------
-    year : str
+    year : str, int
         Analysis year
 
     Returns
     -------
     pandas.DataFrame
     """
+    # check in case year is passed as an int
+    if isinstance(year,str)
+        year = str(year)
     eia_trans_dist_loss = pd.DataFrame()
     old_path = os.getcwd()
     if os.path.exists(f"{paths.local_path}/t_and_d_{year}"):
@@ -99,7 +102,7 @@ def eia_trans_dist_download_extract(year):
             # HOTFIX: URLs for two-word states have space omitted.
             url_a = (
                 "https://www.eia.gov/electricity/state/archive/"
-                + f"{year}"
+                + year
                 + "/"
                 + key.replace(" ", "")
                 + "/xls/"
@@ -172,8 +175,7 @@ def eia_trans_dist_download_extract(year):
 
     eia_trans_dist_loss.columns = eia_trans_dist_loss.columns.str.upper()
     eia_trans_dist_loss = eia_trans_dist_loss.transpose()
-    eia_trans_dist_loss = eia_trans_dist_loss[f"{year}"]
-    eia_trans_dist_loss = eia_trans_dist_loss.to_frame()
+    eia_trans_dist_loss = eia_trans_dist_loss[[year]]
     eia_trans_dist_loss.columns = ["t_d_losses"]
     os.chdir(old_path)
 


### PR DESCRIPTION
1- Updated egrid_facilities.py to account for the fuel category column name in new StEWI data. 
2022 and earlier data had a column called 'Plant primary coal/oil/gas/ other fossil fuel category' containing 'Fuel Category' information. Fuel category in new StEWI data falls under 'Plant primary fuel category' column. Changes were made in the code to extract this info in ELCI2023 config.

2- Updated eia_trans_dist_grid_loss.py to account for new link format for 2023 EIA data: both url_a (archive data) and 'url_b' don't work for 2023 data. url_b ended up downloaded 2022 data and failing on new hampshire. i added a new url format that works for 2023 data.